### PR TITLE
Fix gzip inflation in pipelined HTTP requests

### DIFF
--- a/lib/net/http/pipeline.rb
+++ b/lib/net/http/pipeline.rb
@@ -301,7 +301,7 @@ module Net::HTTP::Pipeline
       begin
         begin
           res = Net::HTTPResponse.read_new @socket
-          res.decode_content = req.decode_content
+          res.decode_content = req.decode_content if req.respond_to?(:decode_content)
         end while res.kind_of? Net::HTTPContinue
 
         res.reading_body @socket, req.response_body_permitted? do

--- a/lib/net/http/pipeline.rb
+++ b/lib/net/http/pipeline.rb
@@ -301,6 +301,7 @@ module Net::HTTP::Pipeline
       begin
         begin
           res = Net::HTTPResponse.read_new @socket
+          res.decode_content = req.decode_content
         end while res.kind_of? Net::HTTPContinue
 
         res.reading_body @socket, req.response_body_permitted? do


### PR DESCRIPTION
It appears that pipelined HTTP requests where the response is gzip compressed are not being re-inflated automatically, which net/http can usually handle automatically for non-pipelined requests.

The source of Ruby 2.2 and others has automatic response inflation, but it requires the `deflate_content` attr-accessor to be set to true in the response instance:
https://github.com/ruby/ruby/blob/ruby_2_2/lib/net/http/response.rb#L250

This is set within the Net::GenericRequest by default if the accept-encoding header is going to be turned on for the request: https://github.com/ruby/ruby/blob/ruby_2_2/lib/net/http/generic_request.rb#L36

Could this be merged and a new version of the Gem released please @drbrain ?